### PR TITLE
Experiment with performance of LengthSquared

### DIFF
--- a/vec3/lsq.s
+++ b/vec3/lsq.s
@@ -1,0 +1,86 @@
+// These are all alternate implementations of LengthSquared in ASM
+// These are all slower since they can't be inlined so they spec a ton
+// of time putting and taking stuff on the stack
+
+// This is basically the same implementation as the pure Go function 
+TEXT ·lensq(SB), 4, $0 
+    // Grab function parameters off the stack
+    MOVSD  x+0(FP),X0
+    MOVSD  y+8(FP),X1
+    MOVSD  z+16(FP),X2
+
+    MULSD  X1,X1
+    MULSD  X0,X0
+    MULSD  X2,X2
+    ADDSD  X1,X0
+    ADDSD  X2,X0
+
+    // Place return val in correct location on stack
+    MOVSD  X0,ret+24(FP)
+    RET
+
+TEXT ·lensq2(SB), $0
+    MOVSD  x+0(FP),X0
+    MOVSD  y+8(FP),X1
+    MOVSD  z+16(FP),X2
+
+    // x2 = x2*x2
+    VMULSD X2,X2,X2
+    // x1 = (x1 * x1) + x2
+    VFMADD132SD X1,X2,X1
+    // x0 = (x0 * x0) + x1
+    VFMADD132SD X0,X1,X0
+    
+    MOVSD  X0,ret+24(FP)
+    RET
+
+TEXT ·lensq3(SB), 4, $0 
+    MOVSD  x+0(FP),X0
+    MOVSD  y+8(FP),X1
+    MOVSD  z+16(FP),X2
+
+    VMOVQ  X2,X2
+    VUNPCKLPD X1,X0,X1
+    VINSERTF128 $0x1,X2,Y1,Y1
+    VMULPD Y1,Y1,Y1
+    VHADDPD X1,X1,X0
+    VEXTRACTF128 $0x1,Y1,X1
+    VADDSD X1,X0,X0
+    VZEROUPPER 
+
+    MOVSD  X0,ret+24(FP)
+    RET
+
+TEXT ·lensq4(SB), 4, $0 
+    MOVSD  x+0(FP),X0
+    MOVSD  y+8(FP),X1
+    MOVSD  z+16(FP),X2
+
+    VMOVQ  X2,X2
+    VUNPCKLPD X1,X0,X0
+    VINSERTF128 $0x1,X2,Y0,Y0
+    VMULPD Y0,Y0,Y0
+    VMOVAPS X0,X1
+    VEXTRACTF128 $0x1,Y0,X0
+    VADDPD X0,X1,X0
+    VUNPCKHPD X0,X0,X1
+    VADDSD X1,X0,X0
+    VZEROUPPER 
+
+    MOVSD  X0,ret+24(FP)
+    RET
+
+TEXT ·lensq5(SB), 4, $0 
+    MOVSD  x+0(FP),X0
+    MOVSD  y+8(FP),X1
+    MOVSD  z+16(FP),X2
+
+    VMOVQ  X2,X2
+    VUNPCKLPD X1,X0,X0
+    VMULPD X2,X2,X2
+    VFMADD132PD X0,X2,X0
+    VUNPCKHPD X0,X0,X1
+    VADDSD X1,X0,X0
+
+    MOVSD  X0,ret+24(FP)
+    RET

--- a/vec3/vec3.go
+++ b/vec3/vec3.go
@@ -12,6 +12,15 @@ type Vec3 struct {
 	Z float64
 }
 
+// These are all alternate implementations of LengthSquared in ASM
+// These are all slower since they can't be inlined so they spec a ton
+// of time putting and taking stuff on the stack
+func lensq(x, y, z float64) float64
+func lensq2(x, y, z float64) float64
+func lensq3(x, y, z float64) float64
+func lensq4(x, y, z float64) float64
+func lensq5(x, y, z float64) float64
+
 // LengthSquared length squared of the vector (duh)
 func (v Vec3) LengthSquared() float64 {
 	return v.Dot(v)

--- a/vec3/vec3_test.go
+++ b/vec3/vec3_test.go
@@ -1,0 +1,172 @@
+package vec3
+
+import (
+	"math"
+	"testing"
+)
+
+func isCloseEnough(a, b float64) bool {
+	tolerance := 0.00001
+	return math.Abs(a-b) < tolerance
+}
+
+func TestLenSqASM1(t *testing.T) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	actualLen := vector.X*vector.X + vector.Y*vector.Y + vector.Z*vector.Z
+	if vlen := lensq(vector.X, vector.Y, vector.Z); !isCloseEnough(vlen, actualLen) {
+		t.Errorf("vector length incorrect, %f != %f", vlen, actualLen)
+	}
+}
+
+func BenchmarkLenSqASM1(b *testing.B) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	for n := 0; n < b.N; n++ {
+		lensq(vector.X, vector.Y, vector.Z)
+	}
+}
+
+func TestLenSqASM2(t *testing.T) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	actualLen := vector.X*vector.X + vector.Y*vector.Y + vector.Z*vector.Z
+	if vlen := lensq2(vector.X, vector.Y, vector.Z); !isCloseEnough(vlen, actualLen) {
+		t.Errorf("vector length incorrect, %f != %f", vlen, actualLen)
+	}
+}
+
+func BenchmarkLenSqASM2(b *testing.B) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	for n := 0; n < b.N; n++ {
+		lensq2(vector.X, vector.Y, vector.Z)
+	}
+}
+
+func TestLenSqASM3(t *testing.T) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	actualLen := vector.X*vector.X + vector.Y*vector.Y + vector.Z*vector.Z
+	if vlen := lensq3(vector.X, vector.Y, vector.Z); !isCloseEnough(vlen, actualLen) {
+		t.Errorf("vector length incorrect, %f != %f", vlen, actualLen)
+	}
+}
+
+func BenchmarkLenSqASM3(b *testing.B) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	for n := 0; n < b.N; n++ {
+		lensq3(vector.X, vector.Y, vector.Z)
+	}
+}
+
+func TestLenSqASM4(t *testing.T) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	actualLen := vector.X*vector.X + vector.Y*vector.Y + vector.Z*vector.Z
+	if vlen := lensq4(vector.X, vector.Y, vector.Z); !isCloseEnough(vlen, actualLen) {
+		t.Errorf("vector length incorrect, %f != %f", vlen, actualLen)
+	}
+}
+
+func BenchmarkLenSqASM4(b *testing.B) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	for n := 0; n < b.N; n++ {
+		lensq4(vector.X, vector.Y, vector.Z)
+	}
+}
+
+func TestLenSqASM5(t *testing.T) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	actualLen := vector.X*vector.X + vector.Y*vector.Y + vector.Z*vector.Z
+	if vlen := lensq5(vector.X, vector.Y, vector.Z); !isCloseEnough(vlen, actualLen) {
+		t.Errorf("vector length incorrect, %f != %f", vlen, actualLen)
+	}
+}
+
+func BenchmarkLenSqASM5(b *testing.B) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	for n := 0; n < b.N; n++ {
+		lensq5(vector.X, vector.Y, vector.Z)
+	}
+}
+
+func TestLenSqGo1(t *testing.T) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	actualLen := vector.X*vector.X + vector.Y*vector.Y + vector.Z*vector.Z
+	if vlen := vector.Dot(vector); !isCloseEnough(vlen, actualLen) {
+		t.Errorf("vector length incorrect, %f != %f", vlen, actualLen)
+	}
+}
+
+func BenchmarkLenSqGo1(b *testing.B) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	for n := 0; n < b.N; n++ {
+		vector.Dot(vector)
+	}
+}
+
+func TestLengthSquared(t *testing.T) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	actualLen := vector.X*vector.X + vector.Y*vector.Y + vector.Z*vector.Z
+	if vlen := vector.LengthSquared(); !isCloseEnough(vlen, actualLen) {
+		t.Errorf("vector length incorrect, %f != %f", vlen, actualLen)
+	}
+}
+
+func BenchmarkLenghtSquared(b *testing.B) {
+	vector := Vec3{
+		X: -10.0,
+		Y: 102.5,
+		Z: 11.0,
+	}
+	for n := 0; n < b.N; n++ {
+		vector.LengthSquared()
+	}
+}

--- a/vec3/vec3_test.go
+++ b/vec3/vec3_test.go
@@ -10,6 +10,22 @@ func isCloseEnough(a, b float64) bool {
 	return math.Abs(a-b) < tolerance
 }
 
+func TestIsCloseEnough1(t *testing.T) {
+	a := 1.0001
+	b := 1.0
+	if isCloseEnough(a, b) {
+		t.Errorf("%f and %f arent close enough, this should have failed", a, b)
+	}
+}
+
+func TestIsCloseEnough2(t *testing.T) {
+	a := 1.000001
+	b := 1.0
+	if !isCloseEnough(a, b) {
+		t.Errorf("%f and %f are close enough, this should not have failed", a, b)
+	}
+}
+
 func TestLenSqASM1(t *testing.T) {
 	vector := Vec3{
 		X: -10.0,


### PR DESCRIPTION
LengthSquared is one of our bottlenecks in performance. I tried to re-implement it in x86_64 assembly and benchmarked several implementations (you can find those in vec3/lsq.s). Turns out the overhead of putting all function parameter on the stack, calling our ASM pulling all the parameters off the stack, then putting the result back on the stack is a nightmare for performance. It blows away any possible performance increase. The pure Go implementation ends up being nicely inlined, and even though the ASM produced isn't the best, since it doesnt incur the cost of all those moves to/from the stack its way faster.

```
goos: linux
goarch: amd64
pkg: github.com/vfrazao-ns1/raytracing1weekend/vec3
BenchmarkLenSqASM1-24        	782524261	         1.53 ns/op	       0 B/op	       0 allocs/op
BenchmarkLenSqASM2-24        	719266898	         1.60 ns/op	       0 B/op	       0 allocs/op
BenchmarkLenSqASM3-24        	623745478	         1.89 ns/op	       0 B/op	       0 allocs/op
BenchmarkLenSqASM4-24        	688862947	         1.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkLenSqASM5-24        	738215010	         1.63 ns/op	       0 B/op	       0 allocs/op
BenchmarkLenSqGo1-24         	1000000000	         0.448 ns/op	       0 B/op	       0 allocs/op
```