### PR TITLE
Improve perf remove allocations

### DIFF
--- a/objects/hittable.go
+++ b/objects/hittable.go
@@ -38,7 +38,6 @@ type HittableList struct {
 
 // Hit were any hittables hit?
 func (hl HittableList) Hit(r ray.Ray, tmin float64, tmax float64, rec *HitRecord) bool {
-	// tempRec := new(HitRecord)
 	hitAnything := false
 	closest := tmax
 
@@ -46,7 +45,6 @@ func (hl HittableList) Hit(r ray.Ray, tmin float64, tmax float64, rec *HitRecord
 		if obj.Hit(r, tmin, closest, rec) {
 			hitAnything = true
 			closest = rec.T
-			// *rec = *tempRec
 		}
 	}
 

--- a/objects/hittable.go
+++ b/objects/hittable.go
@@ -38,15 +38,15 @@ type HittableList struct {
 
 // Hit were any hittables hit?
 func (hl HittableList) Hit(r ray.Ray, tmin float64, tmax float64, rec *HitRecord) bool {
-	tempRec := new(HitRecord)
+	// tempRec := new(HitRecord)
 	hitAnything := false
 	closest := tmax
 
 	for _, obj := range hl.Data {
-		if obj.Hit(r, tmin, closest, tempRec) {
+		if obj.Hit(r, tmin, closest, rec) {
 			hitAnything = true
-			closest = tempRec.T
-			*rec = *tempRec
+			closest = rec.T
+			// *rec = *tempRec
 		}
 	}
 


### PR DESCRIPTION
40% performance improvement in one micro benchmark by eliminating extraneous calls to `new`. 

Before: 19 to 20 seconds wall time
```
(pprof) top 5
Showing nodes accounting for 18.45s, 30.44% of 60.61s total
Dropped 264 nodes (cum <= 0.30s)
Showing top 5 nodes out of 88
      flat  flat%   sum%        cum   cum%
     5.61s  9.26%  9.26%     19.13s 31.56%  runtime.mallocgc
```

After: 12 to 13 seconds wall time

```
(pprof) top5
Showing nodes accounting for 18.02s, 39.00% of 46.21s total
Dropped 175 nodes (cum <= 0.23s)
Showing top 5 nodes out of 70
      flat  flat%   sum%        cum   cum%
     7.28s 15.75% 15.75%     12.96s 28.05%  github.com/vfrazao-ns1/raytracing1weekend/objects.HittableList.Hit
```

One longer benchmark went from ~400 seconds to ~ 390 seconds (~2.5% improvement)